### PR TITLE
Use rustls instead of openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 lazy_static = "1.4"
-reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-webpki-roots"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 lazy_static = "1.4"
-reqwest = "0.11"
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls-webpki-roots", "json"] }


### PR DESCRIPTION
This not only brings performance increase, but it also eliminates the need of openssl when building the lib in build time.